### PR TITLE
A more general power law jet type.

### DIFF
--- a/VegasAfterglow/__init__.py
+++ b/VegasAfterglow/__init__.py
@@ -1,4 +1,4 @@
-from .types import ModelParams, Setups, ObsData, VegasMC, FitResult, ParamDef, Scale, TophatJet, GaussianJet, PowerLawJet, TwoComponentJet, ISM, Wind, Medium, Ejecta, Model, Radiation, Observer, Magnetar
+from .types import ModelParams, Setups, ObsData, VegasMC, FitResult, ParamDef, Scale, TophatJet, GaussianJet, PowerLawJet, PowerLawGeneralJet, TwoComponentJet, ISM, Wind, Medium, Ejecta, Model, Radiation, Observer, Magnetar
 from .runner import Fitter
 
 __all__ = [
@@ -16,6 +16,7 @@ __all__ = [
     "TophatJet",
     "GaussianJet",
     "PowerLawJet",
+    "PowerLawGeneralJet",
     "TwoComponentJet",
     "Ejecta",
     "Model",

--- a/VegasAfterglow/types.py
+++ b/VegasAfterglow/types.py
@@ -2,7 +2,7 @@ import numpy as np
 from dataclasses import dataclass
 from typing import Sequence, Tuple, Callable, Any, Optional
 from enum import Enum
-from .VegasAfterglowC import ModelParams, Setups, ObsData, VegasMC, Ejecta, Wind, Medium, ISM, TophatJet, GaussianJet, PowerLawJet, TwoComponentJet, Radiation, Observer, Model, Magnetar
+from .VegasAfterglowC import ModelParams, Setups, ObsData, VegasMC, Ejecta, Wind, Medium, ISM, TophatJet, GaussianJet, PowerLawJet, PowerLawGeneralJet, TwoComponentJet, Radiation, Observer, Model, Magnetar
 
 @dataclass
 class FitResult:

--- a/include/jet.h
+++ b/include/jet.h
@@ -234,6 +234,71 @@ class PowerLawJet {
     Real const k_{2};        ///< Power-law index for angular dependence
 };
 
+
+/**
+ * <!-- ************************************************************************************** -->
+ * @class PowerLawGeneralJet
+ * @brief Implements a general power-law jet profile where properties follow a power-law distribution with angle.
+ * @details This class provides a model for GRB jets with a power-law decay, characterized by core angles, 
+ *          isotropic equivalent energy E_iso, initial Lorentz factor Gamma0, and power-law indices.
+ * <!-- ************************************************************************************** -->
+ */
+class PowerLawGeneralJet {
+   public:
+    /**
+     * <!-- ************************************************************************************** -->
+     * @brief Constructor: Initialize with core angle, isotropic energy, initial Lorentz factor, and power-law index
+     * @param theta_c Core angle of the jet
+     * @param theta_cG Core angle of the jet
+     * @param E_iso Isotropic equivalent energy
+     * @param Gamma0 Initial Lorentz factor
+     * @param k Power-law index
+     * @param kG Power-law index
+     * @param T0 Duration of the ejecta
+     * @param spreading Flag indicating if the ejecta spreads laterally during evolution
+     * <!-- ************************************************************************************** -->
+     */
+    PowerLawGeneralJet(Real theta_c, Real theta_cG, Real E_iso, Real Gamma0, Real k, Real kG, bool spreading = false, Real T0 = 1 * unit::sec) noexcept
+        : theta_c_(theta_c), theta_cG_(theta_cG), eps_k_(E_iso / (4 * con::pi)), Gamma0_(Gamma0), k_(k), kG_(kG), T0(T0), spreading(spreading) {}
+
+    /**
+     * <!-- ************************************************************************************** -->
+     * @brief Energy per solid angle as a function of phi and theta, with power-law falloff
+     * @param phi Azimuthal angle (unused)
+     * @param theta Polar angle
+     * @return Energy per solid angle with power-law angular dependence
+     * <!-- ************************************************************************************** -->
+     */
+    inline Real eps_k(Real phi, Real theta) const noexcept { return eps_k_ / (1 + fast_pow(theta / theta_c_, k_)); }
+
+    /**
+     * <!-- ************************************************************************************** -->
+     * @brief Initial Lorentz factor as a function of phi and theta, with power-law falloff
+     * @param phi Azimuthal angle (unused)
+     * @param theta Polar angle
+     * @return Lorentz factor with power-law angular dependence
+     * <!-- ************************************************************************************** -->
+     */
+    inline Real Gamma0(Real phi, Real theta) const noexcept {
+        return (Gamma0_ - 1) / (1 + fast_pow(theta / theta_cG_, kG_)) + 1;
+    }
+
+    /// Duration of the ejecta in seconds
+    Real T0{1 * unit::sec};
+    /// Flag indicating if the ejecta spreads laterally during evolution
+    bool spreading{false};
+
+   private:
+    Real const theta_c_{0};  ///< Core angle of the jet
+    Real const theta_cG_{0};  ///< Core angle of the jet
+    Real const eps_k_{0};    ///< Energy per solid angle at the core
+    Real const Gamma0_{1};   ///< Initial Lorentz factor at the core
+    Real const k_{2};        ///< Power-law index for energy angular dependence
+    Real const kG_{2};        ///< Power-law index for LF angular dependence
+};
+
+
+
 /**
  * <!-- ************************************************************************************** -->
  * @namespace math

--- a/include/jet.h
+++ b/include/jet.h
@@ -239,8 +239,10 @@ class PowerLawJet {
  * <!-- ************************************************************************************** -->
  * @class PowerLawGeneralJet
  * @brief Implements a general power-law jet profile where properties follow a power-law distribution with angle.
- * @details This class provides a model for GRB jets with a power-law decay, characterized by core angles, 
- *          isotropic equivalent energy E_iso, initial Lorentz factor Gamma0, and power-law indices.
+ * @details This class provides a model for GRB jets with a power-law decay, characterized by two core angles 
+ *          (one for energy and another for Lorentz factor),  isotropic equivalent energy E_iso,
+ *          initial Lorentz factor Gamma0, and two power-law indices for the energy and Lorentz factor 
+ *          angular profiles.
  * <!-- ************************************************************************************** -->
  */
 class PowerLawGeneralJet {

--- a/pybind/mcmc.cpp
+++ b/pybind/mcmc.cpp
@@ -192,6 +192,9 @@ void MultiBandModel::build_system(Params const& param, Array const& t_eval, Obse
     } else if (config.jet == "powerlaw") {
         jet.eps_k = math::powerlaw(theta_c, E_iso / (4 * con::pi), param.k_jet);
         jet.Gamma0 = math::powerlaw(theta_c, Gamma0, param.k_jet);
+    } else if (config.jet == "powerlawgeneral") {
+        jet.eps_k = math::powerlaw(param.theta_c, E_iso / (4 * con::pi), param.k_jet);
+        jet.Gamma0 = math::powerlaw(param.theta_cG, Gamma0, param.kG_jet);
     } else {
         std::cerr << "Error: Unknown jet type" << std::endl;
     }

--- a/pybind/mcmc.h
+++ b/pybind/mcmc.h
@@ -49,6 +49,7 @@ struct Params {
     double E_iso{1e52};
     double Gamma0{300};
     double theta_c{0.1};
+    double theta_cG{0.1};
     double theta_v{0};
     double theta_w{con::pi / 2};
     double p{2.3};
@@ -58,6 +59,7 @@ struct Params {
     double A_star{0.01};
     double xi_e{1};
     double k_jet{2};
+    double kG_jet{2};
 };
 
 struct ConfigParams {

--- a/pybind/pybind.cpp
+++ b/pybind/pybind.cpp
@@ -31,6 +31,9 @@ PYBIND11_MODULE(VegasAfterglowC, m) {
     m.def("PowerLawJet", &PyPowerLawJet, py::arg("theta_c"), py::arg("E_iso"), py::arg("Gamma0"), py::arg("k"),
           py::arg("spreading") = false, py::arg("duration") = 1, py::arg("magnetar") = py::none());
 
+    m.def("PowerLawGeneralJet", &PyPowerLawGeneralJet, py::arg("theta_c"), py::arg("theta_cG"), py::arg("E_iso"), py::arg("Gamma0"), py::arg("k"), py::arg("kG"),
+          py::arg("spreading") = false, py::arg("duration") = 1, py::arg("magnetar") = py::none());
+
     m.def("TwoComponentJet", &PyTwoComponentJet, py::arg("theta_n"), py::arg("E_iso_n"), py::arg("Gamma0_n"),
           py::arg("theta_w"), py::arg("E_iso_w"), py::arg("Gamma0_w"), py::arg("spreading") = false,
           py::arg("duration") = 1, py::arg("magnetar") = py::none());
@@ -81,6 +84,7 @@ PYBIND11_MODULE(VegasAfterglowC, m) {
         .def_readwrite("E_iso", &Params::E_iso)
         .def_readwrite("Gamma0", &Params::Gamma0)
         .def_readwrite("theta_c", &Params::theta_c)
+        .def_readwrite("theta_cG", &Params::theta_cG)
         .def_readwrite("theta_v", &Params::theta_v)
         .def_readwrite("theta_w", &Params::theta_w)
         .def_readwrite("p", &Params::p)
@@ -90,13 +94,14 @@ PYBIND11_MODULE(VegasAfterglowC, m) {
         .def_readwrite("A_star", &Params::A_star)
         .def_readwrite("xi_e", &Params::xi_e)
         .def_readwrite("k_jet", &Params::k_jet)
+        .def_readwrite("kG_jet", &Params::kG_jet)
         .def("__repr__", [](const Params &p) {
             return "<Params E_iso=" + std::to_string(p.E_iso) + ", Gamma0=" + std::to_string(p.Gamma0) +
-                   ", theta_c=" + std::to_string(p.theta_c) + ", theta_v=" + std::to_string(p.theta_v) +
+                   ", theta_c=" + std::to_string(p.theta_c) + ", theta_cG=" + std::to_string(p.theta_cG) + ", theta_v=" + std::to_string(p.theta_v) +
                    ", theta_w=" + std::to_string(p.theta_w) + ", p=" + std::to_string(p.p) +
                    ", eps_e=" + std::to_string(p.eps_e) + ", eps_B=" + std::to_string(p.eps_B) +
                    ", n_ism=" + std::to_string(p.n_ism) + ", A_star=" + std::to_string(p.A_star) +
-                   ", xi_e=" + std::to_string(p.xi_e) + ", k_jet=" + std::to_string(p.k_jet) + ">";
+                   ", xi_e=" + std::to_string(p.xi_e) + ", k_jet=" + std::to_string(p.k_jet) + ", kG_jet=" + std::to_string(p.kG_jet) + ">";
         });
     // Parameters for modeling that are not used in the MCMC
     py::class_<ConfigParams>(m, "Setups")

--- a/pybind/pymodel.cpp
+++ b/pybind/pymodel.cpp
@@ -87,7 +87,6 @@ Ejecta PyPowerLawGeneralJet(Real theta_c, Real theta_cG, Real E_iso, Real Gamma0
     jet.spreading = spreading;
     jet.T0 = duration;
 
-    /*
     if (magnetar) {
         jet.deps_dt = [=](Real phi, Real theta, Real t) {
             if (theta <= theta_c) {
@@ -97,7 +96,7 @@ Ejecta PyPowerLawGeneralJet(Real theta_c, Real theta_cG, Real E_iso, Real Gamma0
                 return 0.;
             }
         };
-    } */
+    } 
 
     return jet;
 }

--- a/pybind/pymodel.cpp
+++ b/pybind/pymodel.cpp
@@ -79,6 +79,29 @@ Ejecta PyPowerLawJet(Real theta_c, Real E_iso, Real Gamma0, Real k, bool spreadi
     return jet;
 }
 
+Ejecta PyPowerLawGeneralJet(Real theta_c, Real theta_cG, Real E_iso, Real Gamma0, Real k, Real kG, bool spreading, Real duration,
+                     std::optional<PyMagnetar> magnetar) {
+    Ejecta jet;
+    jet.eps_k = [=](Real phi, Real theta) { return E_iso / (1 + fast_pow(theta / theta_c, k)); };
+    jet.Gamma0 = [=](Real phi, Real theta) { return (Gamma0 - 1) / (1 + fast_pow(theta / theta_cG, kG)) + 1; };
+    jet.spreading = spreading;
+    jet.T0 = duration;
+
+    /*
+    if (magnetar) {
+        jet.deps_dt = [=](Real phi, Real theta, Real t) {
+            if (theta <= theta_c) {
+                Real tt = 1 + t / magnetar->t_0;
+                return magnetar->L_0 * std::pow(tt, -magnetar->q);
+            } else {
+                return 0.;
+            }
+        };
+    } */
+
+    return jet;
+}
+
 Ejecta PyTwoComponentJet(Real theta_n, Real E_iso_n, Real Gamma0_n, Real theta_w, Real E_iso_w, Real Gamma0_w,
                          bool spreading, Real duration, std::optional<PyMagnetar> magnetar) {
     Ejecta jet;

--- a/pybind/pymodel.h
+++ b/pybind/pymodel.h
@@ -80,6 +80,23 @@ Ejecta PyPowerLawJet(Real theta_c, Real E_iso, Real Gamma0, Real k, bool spreadi
                      std::optional<PyMagnetar> magnetar = std::nullopt);
 
 /**
+ * @brief Creates a general power-law jet model 
+ *
+ * @param theta_c Core angle of the jet for energy [radians]
+ * @param theta_cG Core angle of the jet for LF [radians]
+ * @param E_iso Isotropic-equivalent energy at the center [erg]
+ * @param Gamma0 Initial Lorentz factor at the center
+ * @param k Power-law index for energy
+ * @param kG Power-law index for LF
+ * @param spreading Whether to include jet lateral spreading
+ * @param duration Engine activity time [seconds]
+ * @param magnetar Optional magnetar model
+ * @return Ejecta Configured jet with power-law profile
+ */
+Ejecta PyPowerLawGeneralJet(Real theta_c, Real theta_cG, Real E_iso, Real Gamma0, Real k, Real kG, bool spreading = false, Real duration = 1,
+                     std::optional<PyMagnetar> magnetar = std::nullopt);
+                     
+/**
  * @brief Creates a two-component jet model with different properties for narrow and wide components
  * @param theta_n Core angle of the narrow component [radians]
  * @param E_iso_n Isotropic-equivalent energy of the narrow component [erg]

--- a/pybind/pymodel.h
+++ b/pybind/pymodel.h
@@ -83,7 +83,7 @@ Ejecta PyPowerLawJet(Real theta_c, Real E_iso, Real Gamma0, Real k, bool spreadi
  * @brief Creates a general power-law jet model 
  *
  * @param theta_c Core angle of the jet for energy [radians]
- * @param theta_cG Core angle of the jet for LF [radians]
+ * @param theta_cG Core angle of the jet for Lorentz factor [radians]
  * @param E_iso Isotropic-equivalent energy at the center [erg]
  * @param Gamma0 Initial Lorentz factor at the center
  * @param k Power-law index for energy


### PR DESCRIPTION
I have implemented a more general power law jet type, where the core angle theta_c and angular profile power law index k are allowed to be different between energy and Lorentz factor profiles. It is called PowerLawGeneralJet and it is implemented similarly to the currently-existing PowerLawJet model. PowerLawGeneralJet has two additional parameters: theta_cG (the jet core angle) and kG, the power law index, for the Lorentz factor (theta_c and k refers to the parameter that correspond to the energy profile). 


